### PR TITLE
Re-enable --skip-rebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ clean-css-cli 4.0 introduces some breaking changes:
 --source-map                   Enables building input's source map
 --source-map-inline-sources    Enables inlining sources inside source maps
 --with-rebase                  Enables URLs rebasing
---skip-rebase                  Disables URLs rebasing (overwrites with-rebase).
+--skip-rebase                  Disables URLs rebasing
 ```
 
 ## Compatibility modes

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ clean-css-cli 4.0 introduces some breaking changes:
 --source-map                   Enables building input's source map
 --source-map-inline-sources    Enables inlining sources inside source maps
 --with-rebase                  Enables URLs rebasing
+--skip-rebase                  Disables URLs rebasing (overwrites with-rebase).
 ```
 
 ## Compatibility modes
@@ -423,7 +424,7 @@ which sets all units rounding precision to 3 digits except `px` unit precision o
 
 ## How to rebase relative image URLs?
 
-clean-css-cli will rebase paths it automatically for you when full paths to input files are passed, and `--with-rebase` & `--output` options are used, e.g
+clean-css-cli will rebase paths automatically for you when full paths to input files are passed, and `--with-rebase` & `--output` options are used, but not if `--skip-rebase` is used, e.g
 
 ```css
 /*! one.css */

--- a/index.js
+++ b/index.js
@@ -124,7 +124,7 @@ function cli(process, beforeMinifyCallback) {
     fs.mkdirSync(options.output, {recursive: true});
   }
 
-  if (inputOptions.withRebase && ('output' in inputOptions) && inputOptions.output.length > 0) {
+  if (inputOptions.withRebase && ('output' in inputOptions) && inputOptions.output.length > 0 && !inputOptions.skipRebase) {
     if (isDirectory(path.resolve(inputOptions.output))) {
       options.rebaseTo = path.resolve(inputOptions.output);
     } else {

--- a/index.js
+++ b/index.js
@@ -38,6 +38,7 @@ function cli(process, beforeMinifyCallback) {
     .option('--source-map', 'Enables building input\'s source map')
     .option('--source-map-inline-sources', 'Enables inlining sources inside source maps')
     .option('--with-rebase', 'Enable URLs rebasing')
+    .option('--skip-rebase', 'Disable URLs rebasing')
     .option('--watch', 'Runs CLI in watch mode');
 
   program.on('--help', function () {


### PR DESCRIPTION
Closes #87

`--skip-rebase` should work again now, in theory it should block any url rebasing if present.

So this:
```css
@import "fonts.css"
```
Should now become this when the flag is present:
```css
@import url(fonts.css)
```